### PR TITLE
Fixed Typo in description for alluvial chart

### DIFF
--- a/charts/alluvial.js
+++ b/charts/alluvial.js
@@ -4,7 +4,7 @@ raw.charts.alluvial = function(){
 
 		title : 'Alluvial diagram (fineo-like)',
 		image : 'charts/imgs/alluvial.png',
-		description : 'Alluvial diagrams allow to represent flows and to see correlations between categorical dimensions, visually linking to the number of elements sharing the same categories. It is useful to see the evolution of cluster (such as the number of people belonging to a specific group). It can also be used to represent <a href="http://en.wikipedia.org/wiki/Bipartite_graph">bipartite graphs</a>, using each node group as dimensions.<br>Mainly based on our previous work with <a href="http://www.densitydesign.org/research/fineo/">Fineo</a>, it is inspired by on <a href="http://bost.ocks.org/mike/sankey/">http://bost.ocks.org/mike/sankey/</a>.',
+		description : 'Alluvial diagrams allow to represent flows and to see correlations between categorical dimensions, visually linking to the number of elements sharing the same categories. It is useful to see the evolution of cluster (such as the number of people belonging to a specific group). It can also be used to represent <a href="http://en.wikipedia.org/wiki/Bipartite_graph">bipartite graphs</a>, using each node group as dimensions.<br>Mainly based on our previous work with <a href="http://www.densitydesign.org/research/fineo/">Fineo</a>, it is inspired by <a href="http://bost.ocks.org/mike/sankey/">http://bost.ocks.org/mike/sankey/</a>.',
 		model : raw.models.graph({}),
 
 		options : {


### PR DESCRIPTION
Same as #28, but rebased against master @ 6ba7bb528b7b847a10285d9185a0167955f1a689
