### PR TITLE
limit node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
   "devDependencies": {
     "node-sass": "^4.14.1",
     "prettier": "^2.1.2"
+  },
+  "engines": {
+    "node": "^14"
   }
 }


### PR DESCRIPTION
`node-sass` v4.14.1 [works with node up to v14](https://github.com/sass/node-sass/releases/tag/v4.14.1)
`yarn install` hangs and fails when using node v15 and v16, until `node-sass` is updated this will prevent this from happening