### PR TITLE
dockerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:14-alpine
+
+EXPOSE 3000
+
+# this counts on the rawgraphs repository directory being mounted in /app,
+# as done by docker-compose.yml
+
+WORKDIR /app
+
+ENTRYPOINT yarn install && yarn start --host 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to run your instance of RAWGraphs locally on your machine, be sure y
 If you want to run your instance of RAWGraphs locally on your machine, be sure you have the following requirements installed.
 
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) (it could be used through the interface of [GitHub Desktop](https://desktop.github.com/))
-- [Node.js](https://nodejs.org/en/)
+- [Node.js](https://nodejs.org/en/) (version 14)
 - [Yarn](https://yarnpkg.com/getting-started/install)
 
 ### Instructions (macOS)
@@ -62,6 +62,16 @@ You can also build your own version and upload it on your server by running the 
 ```shell
 yarn build
 ```
+
+### Instructions (docker on any platform)
+
+You might have a newer version of node installed. If so, you could benefit from running the `RAWGraphs-app` in an isolated container. To do this you will need to have docker installed. Then open the terminal in the root folder of the repository and type:
+
+```shell
+docker-compose up
+```
+
+This will install and start yarn. If you want to build your own production version, you would need to modify your docker configuration accordingly.
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+
+services:
+  rawgraphs:
+    container_name: rawgraphs
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+    # tty: true
+    stdin_open: true
+    ports:
+      - 3000:3000
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       dockerfile: Dockerfile
     volumes:
       - .:/app
-    # tty: true
     stdin_open: true
     ports:
       - 3000:3000


### PR DESCRIPTION
Added docker container and compose that allow working with the entire source directory as a mount point. This allows easily running a development server in a local container.

One reason this is particularly useful is that node v14 that is used by `RAWGraphs-app` might be in conflict with other versions installed on your system. This is a potential solution for #353 and an example of the solution adopted in #307.